### PR TITLE
Add exponential backoff for user-crd watches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: "3.13"
+          cache: true
+
+      - name: Install dependencies
+        run: pdm install
+
+      - name: Run tests
+        run: pdm run pytest
+
   build-image:
     runs-on: ubuntu-latest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "koreo-controller"
-version = "0.1.9"
+version = "0.1.10"
 description = "Koreo Controller runs Koreo Core as a Kubernetes Controller."
 authors = [
     {name = "Eric Larssen", email = "eric.larssen@realkinetic.com"},
     {name = "Robert Kluin", email = "robert.kluin@realkinetic.com"},
 ]
 dependencies = [
-    "koreo-core==0.1.10",
+    "koreo-core==0.1.8",
     "cel-python==0.2.0",
     "kr8s==0.20.6",
     "uvloop==0.21.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     {name = "Robert Kluin", email = "robert.kluin@realkinetic.com"},
 ]
 dependencies = [
-    "koreo-core==0.1.8",
+    "koreo-core==0.1.10",
     "cel-python==0.2.0",
     "kr8s==0.20.6",
     "uvloop==0.21.0",

--- a/tests/controller/test_integration.py
+++ b/tests/controller/test_integration.py
@@ -67,7 +67,7 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
 
         request_queue = scheduler.RequestQueue[tuple[str, str]]()
 
-        async def event_handler(event: str, resource: kr8s._objects.APIObject):
+        async def event_handler(event: str, resource: kr8s._objects.APIObject, **_):
             await request_queue.put(
                 scheduler.Request(
                     at=time.monotonic(), payload=(resource.full_kind, resource.name)
@@ -76,7 +76,8 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
             return True
 
         event_config = events.Configuration(
-            event_handler=event_handler, namespace=namespace
+            event_handler=event_handler,
+            namespace=namespace,
         )
 
         processed_counts = {}

--- a/tests/controller/test_reconciler.py
+++ b/tests/controller/test_reconciler.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 import random
 import string
 import unittest
@@ -15,7 +15,8 @@ def _get_name():
 
 
 class TestReconcileResource(unittest.IsolatedAsyncioTestCase):
-    async def test_reconcile_uncached_is_a_noop(self):
+    @patch("kr8s.asyncio.api")
+    async def test_reconcile_uncached_is_a_noop(self, api_mock):
         resource = reconcile.Resource(
             group="unit.test",
             version="v1test1",
@@ -32,7 +33,8 @@ class TestReconcileResource(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(result)
 
-    async def test_reconcile_cached(self):
+    @patch("kr8s.asyncio.api")
+    async def test_reconcile_cached(self, api_mock):
         cacher, queue = reconcile.get_event_handler(namespace="unit-test")
 
         resource_name = _get_name()


### PR DESCRIPTION
The retries on a failed watch are too aggressive. This add an exponential backoff for watch restarts.