### PR TITLE
Reduce the amount of fuzzy-comparisons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koreo-controller"
-version = "0.1.10"
+version = "0.1.11"
 description = "Koreo Controller runs Koreo Core as a Kubernetes Controller."
 authors = [
     {name = "Eric Larssen", email = "eric.larssen@realkinetic.com"},

--- a/src/controller/reconcile.py
+++ b/src/controller/reconcile.py
@@ -364,7 +364,7 @@ def _check_cache_and_get_lock(
 
     # Last outcome was a retry, need to check how close we are to decide.
     if isinstance(last_reconcile.outcome, Retry):
-        if seconds_to_wait > 1:
+        if seconds_to_wait:
             return None
 
         return cached_resource.reconcile_lock

--- a/src/controller/scheduler.py
+++ b/src/controller/scheduler.py
@@ -87,7 +87,7 @@ async def orchestrator[T](
         else:
             up_next = heapq.heappop(request_schedule)
             next_scheduled_work = up_next.at - time.monotonic()
-            if next_scheduled_work < 1:
+            if next_scheduled_work <= 0:
                 await work.put(up_next)
                 continue
 


### PR DESCRIPTION
We're using time.monotonic to ensure a strictly increasing value, and the sequencing of calls should ensure fuzzy fuzzy-comparisons aren't needed. This was originally done as a theoretical efficiency / performance boost, but with short retry delays it causes tight looping.