### PR TITLE
Pass the k8s api into reconciler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "koreo-controller"
-version = "0.1.11"
+version = "0.1.12"
 description = "Koreo Controller runs Koreo Core as a Kubernetes Controller."
 authors = [
     {name = "Eric Larssen", email = "eric.larssen@realkinetic.com"},
     {name = "Robert Kluin", email = "robert.kluin@realkinetic.com"},
 ]
 dependencies = [
-    "koreo-core==0.1.8",
+    "koreo-core==0.1.9",
     "cel-python==0.2.0",
     "kr8s==0.20.6",
     "uvloop==0.21.0",

--- a/src/controller/custom_workflow.py
+++ b/src/controller/custom_workflow.py
@@ -1,10 +1,36 @@
 import asyncio
+import logging
 
 import kr8s.asyncio
 
 from controller import events
 from controller import scheduler
 from controller import reconcile
+
+logger = logging.getLogger("koreo.controller.reconcile")
+
+
+def _configure_reconciler(
+    api: kr8s.asyncio.Api,
+):
+    async def wrapped(
+        payload: reconcile.Resource,
+        ok_frequency_seconds: int,
+        sys_error_retries: int,
+        user_retries: int,
+    ):
+        try:
+            return await reconcile.reconcile_resource(
+                api=api,
+                payload=payload,
+                ok_frequency_seconds=ok_frequency_seconds,
+                sys_error_retries=sys_error_retries,
+                user_retries=user_retries,
+            )
+        except Exception as err:
+            logger.exception(f"Error reconciling resource '{err}'")
+
+    return wrapped
 
 
 async def workflow_controller_system(
@@ -19,7 +45,7 @@ async def workflow_controller_system(
     )
 
     scheduler_config = scheduler.Configuration(
-        work_processor=reconcile.reconcile_resource
+        work_processor=_configure_reconciler(api=api)
     )
 
     async with asyncio.TaskGroup() as tg:

--- a/src/controller/kind_lookup.py
+++ b/src/controller/kind_lookup.py
@@ -23,8 +23,7 @@ async def get_full_kind(
     lookup_lock = _lookup_locks.get(lookup_kind)
     if lookup_lock:
         try:
-            async with asyncio.timeout(LOOKUP_TIMEOUT):
-                await lookup_lock.wait()
+            await asyncio.wait_for(lookup_lock.wait(), timeout=LOOKUP_TIMEOUT)
         except asyncio.TimeoutError:
             pass
 

--- a/src/controller/reconcile.py
+++ b/src/controller/reconcile.py
@@ -168,13 +168,12 @@ def _hash_resource(resource: dict):
 
 
 async def reconcile_resource(
+    api: kr8s.asyncio.Api,
     payload: Resource,
     ok_frequency_seconds: int,
     sys_error_retries: int,
     user_retries: int,
 ):
-    api = await kr8s.asyncio.api()
-
     if not (cached_resource := _load_cached_resource(payload)):
         return None
 

--- a/tests/controller/test_reconciler.py
+++ b/tests/controller/test_reconciler.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 import random
 import string
 import unittest
@@ -15,8 +15,9 @@ def _get_name():
 
 
 class TestReconcileResource(unittest.IsolatedAsyncioTestCase):
-    @patch("kr8s.asyncio.api")
-    async def test_reconcile_uncached_is_a_noop(self, api_mock):
+    async def test_reconcile_uncached_is_a_noop(self):
+        mock_api = AsyncMock(kr8s.asyncio.Api)
+
         resource = reconcile.Resource(
             group="unit.test",
             version="v1test1",
@@ -25,6 +26,7 @@ class TestReconcileResource(unittest.IsolatedAsyncioTestCase):
             namespace=_get_name(),
         )
         result = await reconcile.reconcile_resource(
+            api=mock_api,
             payload=resource,
             ok_frequency_seconds=60,
             sys_error_retries=0,
@@ -33,8 +35,9 @@ class TestReconcileResource(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(result)
 
-    @patch("kr8s.asyncio.api")
-    async def test_reconcile_cached(self, api_mock):
+    async def test_reconcile_cached(self):
+        mock_api = AsyncMock(kr8s.asyncio.Api)
+
         cacher, queue = reconcile.get_event_handler(namespace="unit-test")
 
         resource_name = _get_name()
@@ -73,6 +76,7 @@ class TestReconcileResource(unittest.IsolatedAsyncioTestCase):
         )
 
         result = await reconcile.reconcile_resource(
+            api=mock_api,
             payload=resource,
             ok_frequency_seconds=60,
             sys_error_retries=0,


### PR DESCRIPTION
Rather than instantiating a new k8s api on each reconcile, pass the api into the reconciler.