### PR TITLE
Bump Koreo Core Version

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "all", "test", "tooling"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:994141b694c96209d632413a5929ba99ad3208b7bea8cf6f51fad8eaf90ff7b8"
+content_hash = "sha256:be022792e65393a95bd40e758ddd53bdf5b905b56c5d629f438c15be3d950277"
 
 [[metadata.targets]]
 requires_python = "==3.13.*"
@@ -315,7 +315,7 @@ files = [
 
 [[package]]
 name = "koreo-core"
-version = "0.1.13"
+version = "0.1.15"
 requires_python = ">=3.13"
 summary = "Type-safe and testable KRM Templates and Workflows."
 groups = ["default", "all"]
@@ -326,23 +326,23 @@ dependencies = [
     "kr8s==0.20.7",
 ]
 files = [
-    {file = "koreo_core-0.1.13-py3-none-any.whl", hash = "sha256:3f809dc89c7cc0e9aed4cf726d7dd46499f1e3a49821241270e546e420ad7339"},
-    {file = "koreo_core-0.1.13.tar.gz", hash = "sha256:7ececc1d94d34271ec7f10ecd329945d7b62761bce1e5a9714cfd1de46e7db9d"},
+    {file = "koreo_core-0.1.15-py3-none-any.whl", hash = "sha256:72c40463b95826d7c3bbb89bf6ce86b32cc172630962cec79e94c252b094f1d2"},
+    {file = "koreo_core-0.1.15.tar.gz", hash = "sha256:249f7626b5eabd32b74d108fcacad69834002c56b059603ba28ab4d0af529d21"},
 ]
 
 [[package]]
 name = "koreo-core"
-version = "0.1.13"
+version = "0.1.15"
 extras = ["test", "tooling"]
 requires_python = ">=3.13"
 summary = "Type-safe and testable KRM Templates and Workflows."
 groups = ["all"]
 dependencies = [
-    "koreo-core==0.1.13",
+    "koreo-core==0.1.15",
 ]
 files = [
-    {file = "koreo_core-0.1.13-py3-none-any.whl", hash = "sha256:3f809dc89c7cc0e9aed4cf726d7dd46499f1e3a49821241270e546e420ad7339"},
-    {file = "koreo_core-0.1.13.tar.gz", hash = "sha256:7ececc1d94d34271ec7f10ecd329945d7b62761bce1e5a9714cfd1de46e7db9d"},
+    {file = "koreo_core-0.1.15-py3-none-any.whl", hash = "sha256:72c40463b95826d7c3bbb89bf6ce86b32cc172630962cec79e94c252b094f1d2"},
+    {file = "koreo_core-0.1.15.tar.gz", hash = "sha256:249f7626b5eabd32b74d108fcacad69834002c56b059603ba28ab4d0af529d21"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "koreo-controller"
-version = "0.1.17"
+version = "0.1.18"
 description = "Koreo Controller runs Koreo Core as a Kubernetes Controller."
 authors = [
     {name = "Eric Larssen", email = "eric.larssen@realkinetic.com"},
     {name = "Robert Kluin", email = "robert.kluin@realkinetic.com"},
 ]
 dependencies = [
-    "koreo-core==0.1.13",
+    "koreo-core==0.1.15",
     "cel-python==0.3.0",
     "kr8s==0.20.7",
     "uvloop==0.21.0",


### PR DESCRIPTION
A bug was fixed in Koreo Core that caused koreo resource updates to correctly re-prepare workflows with dependencies when using refSwitch.